### PR TITLE
Implement logger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ all: check test race
 .PHONY: check
 check:
 	go build ./roc
+	go test ./roc -run xxx
 	golangci-lint run ./roc
 
 .PHONY: test

--- a/roc/log.c
+++ b/roc/log.c
@@ -1,0 +1,6 @@
+#include <roc/log.h>
+#include "_cgo_export.h"
+
+void rocGoLogHandlerProxy(roc_log_level level, char* component, char* message) {
+    rocGoLogHandler(level, component, message);
+}

--- a/roc/log.go
+++ b/roc/log.go
@@ -2,20 +2,93 @@ package roc
 
 /*
 #include <roc/log.h>
+void rocGoLogHandlerProxy(roc_log_level level, char* component, char* message);
 */
 import "C"
+import (
+	"fmt"
+	"log"
+	"sync"
+)
 
-// LogLevel as declared in roc/log.h:53
-type LogLevel int32
+type LogLevel int
 
-// LogLevel enumeration from roc/log.h:53
 const (
-	LogNone  LogLevel = iota
+	LogNone  LogLevel = 0
 	LogError LogLevel = 1
 	LogInfo  LogLevel = 2
 	LogDebug LogLevel = 3
 	LogTrace LogLevel = 4
 )
 
-// LogHandler type as declared in roc/log.h:64
-type LogHandler func(level LogLevel, component string, message string)
+type LoggerFunc func(level LogLevel, component string, message string)
+
+type Logger interface {
+	Print(v ...interface{})
+}
+
+var (
+	loggerFunc LoggerFunc
+	loggerMu   sync.Mutex
+)
+
+//export rocGoLogHandler
+func rocGoLogHandler(level C.roc_log_level, component *C.char, message *C.char) {
+	loggerMu.Lock()
+	defer loggerMu.Unlock()
+
+	if loggerFunc != nil {
+		loggerFunc(LogLevel(level), C.GoString(component), C.GoString(message))
+	}
+}
+
+type defaultLogger struct{}
+
+func (defaultLogger) Print(v ...interface{}) {
+	log.Print(v...)
+}
+
+func makeLoggerFunc(logger Logger) LoggerFunc {
+	return func(level LogLevel, component string, message string) {
+		level_str := ""
+		switch level {
+		case LogError:
+			level_str = "err"
+		case LogInfo:
+			level_str = "inf"
+		case LogDebug:
+			level_str = "dbg"
+		case LogTrace:
+			level_str = "trc"
+		}
+		logger.Print(fmt.Sprintf("[%s] %s: %s", level_str, component, message))
+	}
+}
+
+func init() {
+	SetLoggerFunc(nil)
+}
+
+func SetLogLevel(level LogLevel) {
+	C.roc_log_set_level(C.roc_log_level(level))
+}
+
+func SetLoggerFunc(logFn LoggerFunc) {
+	if logFn == nil {
+		logFn = makeLoggerFunc(defaultLogger{})
+	}
+
+	loggerMu.Lock()
+	defer loggerMu.Unlock()
+
+	loggerFunc = logFn
+	C.roc_log_set_handler(C.roc_log_handler(C.rocGoLogHandlerProxy))
+}
+
+func SetLogger(logger Logger) {
+	if logger == nil {
+		logger = defaultLogger{}
+	}
+
+	SetLoggerFunc(makeLoggerFunc(logger))
+}

--- a/roc/log_test.go
+++ b/roc/log_test.go
@@ -1,0 +1,105 @@
+package roc
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+	"time"
+)
+
+const defaultLogLevel LogLevel = LogError
+
+type testWriter struct {
+	ch chan string
+}
+
+func makeTestWriter() testWriter {
+	return testWriter{
+		// capacity 1 is needed to ensure that at least one
+		// message can be written without blocking
+		ch: make(chan string, 1),
+	}
+}
+
+func (tw testWriter) Write(buf []byte) (int, error) {
+	select {
+	case tw.ch <- string(buf):
+	default:
+		// drop message instead of blocking if the channel is full
+	}
+	return len(buf), nil
+}
+
+func (tw testWriter) wait() string {
+	const waitTimeout = time.Minute
+
+	select {
+	case s := <-tw.ch:
+		return s
+	case <-time.After(waitTimeout):
+		return ""
+	}
+}
+
+func Test_roc_log_default(t *testing.T) {
+	setupFuncs := []func(){
+		func() {},
+		func() { SetLoggerFunc(nil) },
+		func() { SetLogger(nil) },
+	}
+
+	SetLogLevel(LogDebug)
+	defer SetLogLevel(defaultLogLevel)
+
+	for n, setupFn := range setupFuncs {
+		tw := makeTestWriter()
+
+		log.SetOutput(&tw)
+		defer log.SetOutput(ioutil.Discard)
+
+		setupFn()
+
+		ctx, _ := OpenContext(&ContextConfig{})
+		ctx.Close()
+
+		if tw.wait() == "" {
+			t.Fatalf("test %v: expected logs, didn't get them before timeout", n)
+		}
+	}
+}
+
+func Test_roc_log_func(t *testing.T) {
+	SetLogLevel(LogDebug)
+	defer SetLogLevel(defaultLogLevel)
+
+	tw := makeTestWriter()
+	SetLoggerFunc(func(_ LogLevel, component string, message string) {
+		_, _ = tw.Write([]byte(component + ":" + message))
+	})
+	defer SetLoggerFunc(nil)
+
+	ctx, _ := OpenContext(&ContextConfig{})
+	ctx.Close()
+
+	if tw.wait() == "" {
+		t.Fatal("expected logs, didn't get them before timeout")
+	}
+}
+
+func Test_roc_log_interface(t *testing.T) {
+	SetLogLevel(LogDebug)
+	defer SetLogLevel(defaultLogLevel)
+
+	tw := makeTestWriter()
+	logger := log.New(&tw, "", log.Lshortfile)
+
+	SetLogger(logger)
+	defer SetLogger(nil)
+
+	ctx, _ := OpenContext(&ContextConfig{})
+	ctx.Close()
+
+	if tw.wait() == "" {
+		t.Fatal("expected logs, didn't get them before timeout")
+	}
+}

--- a/roc/utils_test.go
+++ b/roc/utils_test.go
@@ -1,8 +1,19 @@
 package roc
 
-import "testing"
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+)
 
 func fail(expected interface{}, got interface{}, t *testing.T) {
 	t.Errorf("Mismatch, expected: %v, got: %v", expected, got)
 	t.FailNow()
+}
+
+func TestMain(m *testing.M) {
+	// by default, disable logging; can be overridden by specific tests
+	log.SetOutput(ioutil.Discard)
+	os.Exit(m.Run())
 }


### PR DESCRIPTION
Resolves #5.

- add SetLogLevel(), SetLoggerFunc(), and SetLogger()
- SetLogger() uses Logger interface compatible with log.Logger
- by default use standard logger instead of plain stderr
- by default disable logging in tests

A note on tests: roc logging is currently synchronous, but likely will
become asynchronous in future; logger tests are designed to work well
in both cases.